### PR TITLE
[Not to be merged] Remove `r_github_packages` only to test Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,5 @@ r_packages:
   - devtools
   - jsonlite
 
-r_github_packages:
-  - ProvTools/provParseR
-
 notifications:
   slack: endtoendprovenance:DNYqXZWhV1c3eRhkjGYyjCEv
-
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,8 @@ r_packages:
   - devtools
   - jsonlite
 
+r_github_packages:
+  - End-to-end-provenance/rdtLite
+
 notifications:
   slack: endtoendprovenance:DNYqXZWhV1c3eRhkjGYyjCEv


### PR DESCRIPTION
## Update

After removing:
```yaml
r_github_packages:
  - ProvTools/provParseR
```
the build succeeded.

## Update 2

After adding:
```yaml
r_github_packages:
  - End-to-end-provenance/rdtLite
```
the build failed.